### PR TITLE
Make dpi argument of savefig an int

### DIFF
--- a/run_digits.py
+++ b/run_digits.py
@@ -65,7 +65,7 @@ def plotfigs2(xx, selectedy, fileprefix=None, printselectionnumbers = False):
         file = fileprefix+str(counter) + '.png'
         if file is not None:
             # print "saving file"
-            plt.savefig(file , dpi='2000')
+            plt.savefig(file , dpi=2000)
 
         begin_at += perpic_m
 


### PR DESCRIPTION
Beforehand, it was a string, which caused an error:

```
  File "/usr/agent007/anaconda2/lib/python2.7/site-packages/matplotlib/backend_bases.py", line 2171, in print_figure
    self.figure.dpi = dpi
  File "/usr/agent007/anaconda2/lib/python2.7/site-packages/matplotlib/figure.py", line 417, in _set_dpi
    self.set_size_inches(*self.get_size_inches())
  File "/usr/agent007/anaconda2/lib/python2.7/site-packages/matplotlib/figure.py", line 718, in set_size_inches
    dpival = self.dpi / ratio
TypeError: unsupported operand type(s) for /: 'str' and 'int
```

After this change, I can run run_digits.py, which generates the images containing criticisms.